### PR TITLE
Support symfony/console 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^5.3.0 || ^7.0",
         "phpunit/phpunit": "^4.0.0 || ^5.0",
-        "symfony/console": "^2.3.0"
+        "symfony/console": "^2.3 || ^3.0"
     },
     "bin": [
         "covers-validator"

--- a/tests/Command/ValidateCommandTest.php
+++ b/tests/Command/ValidateCommandTest.php
@@ -75,7 +75,7 @@ class ValidateCommandTest extends BaseTestCase
         $this->assertGreaterThan(0, $exitCode);
         $display = $commandTester->getDisplay();
         $this->assertRegExp('/Invalid - /', $display);
-        $this->assertRegExp('/' . preg_quote(CoversValidator::NAME, '/') . ' (?:version )' . preg_quote(CoversValidator::VERSION, '/') . '/', $display);
+        $this->assertRegExp('/' . preg_quote(CoversValidator::NAME, '/') . ' (?:version )?' . preg_quote(CoversValidator::VERSION, '/') . '/', $display);
         $this->assertRegExp('/There were 1 test\(s\) with invalid @covers tags./', $display);
     }
 

--- a/tests/Command/ValidateCommandTest.php
+++ b/tests/Command/ValidateCommandTest.php
@@ -75,7 +75,7 @@ class ValidateCommandTest extends BaseTestCase
         $this->assertGreaterThan(0, $exitCode);
         $display = $commandTester->getDisplay();
         $this->assertRegExp('/Invalid - /', $display);
-        $this->assertRegExp('/' . preg_quote(CoversValidator::NAME . ' version ' . CoversValidator::VERSION) . '/', $display);
+        $this->assertRegExp('/' . preg_quote(CoversValidator::NAME, '/') . ' (?:version )' . preg_quote(CoversValidator::VERSION, '/') . '/', $display);
         $this->assertRegExp('/There were 1 test\(s\) with invalid @covers tags./', $display);
     }
 


### PR DESCRIPTION
3.0 has been release for a while, covers-validator is forcing our projects on 2.3 branch. There does not seem much in the way for upgrading to 3.0. 