### PR TITLE
Raise memory limit to 512M if below, closes #16

### DIFF
--- a/covers-validator
+++ b/covers-validator
@@ -12,5 +12,32 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
 
 use OckCyp\CoversValidator\Application\CoversValidator;
 
+error_reporting(-1);
+
+if (function_exists('ini_set')) {
+    @ini_set('display_errors', 1);
+    $memoryInBytes = function ($value) {
+        $unit = strtolower(substr($value, -1));
+        $value = (int) $value;
+        switch($unit) {
+            case 'g':
+                $value *= 1024;
+            // no break (cumulative multiplier)
+            case 'm':
+                $value *= 1024;
+            // no break (cumulative multiplier)
+            case 'k':
+                $value *= 1024;
+        }
+        return $value;
+    };
+    $memoryLimit = trim(ini_get('memory_limit'));
+    // Increase memory_limit if it is lower than 512MB
+    if ($memoryLimit != -1 && $memoryInBytes($memoryLimit) < 1024 * 1024 * 512) {
+        @ini_set('memory_limit', '512M');
+    }
+    unset($memoryInBytes, $memoryLimit);
+}
+
 $app = new CoversValidator;
 $app->run();


### PR DESCRIPTION
When executing covers-validator on the default PHP 5.6 docker image with
an application with ca. 5 900 tests, the default set memory limit of PHP
with 128M[1] caused a limit violation and terminated the process.

Fix is to conditionally raise the memory limit to 512M if it is below.

That value *should* prevent first-use memory limit errors in such and
similar configurations. If however the utility needs more memory (which
might the case with more tests and/or a larger code base), this 512M then
still may not be enough - just saying.

Additionally error reporting is set to all kind of errors and the display
of errors is switched on. This is generally useful as the files
in the `@covers` notations are then also parsed and deprecation or similar
errors are displayed (w/o making the covers validation fail unless there
is a failure with `@covers` notations as well).

Refs:

- [1] http://php.net/manual/en/ini.core.php#ini.memory-limit

- oradwell/covers-validator#16