### PR TITLE
Raise memory limit to 512M if below, closes #16

### DIFF
--- a/covers-validator
+++ b/covers-validator
@@ -12,5 +12,32 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
 
 use OckCyp\CoversValidator\Application\CoversValidator;
 
+error_reporting(-1);
+
+if (function_exists('ini_set')) {
+    @ini_set('display_errors', 1);
+    $memoryInBytes = function ($value) {
+        $unit = strtolower(substr($value, -1));
+        $value = (int) $value;
+        switch($unit) {
+            case 'g':
+                $value *= 1024;
+            // no break (cumulative multiplier)
+            case 'm':
+                $value *= 1024;
+            // no break (cumulative multiplier)
+            case 'k':
+                $value *= 1024;
+        }
+        return $value;
+    };
+    $memoryLimit = trim(ini_get('memory_limit'));
+    // Increase memory_limit if it is lower than 512MB
+    if ($memoryLimit != -1 && $memoryInBytes($memoryLimit) < 1024 * 1024 * 512) {
+        @ini_set('memory_limit', '512M');
+    }
+    unset($memoryInBytes, $memoryLimit);
+}
+
 $app = new CoversValidator;
 $app->run();


### PR DESCRIPTION
Same as #17 just against 0.5. Done as Travis checks more PHP versions and I'm also bound to 0.5 use (yet).