### PR TITLE
Support symfony/console ^5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.0",
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0",
-        "symfony/console": "^2.7 || ^3.0 || ^4.0"
+        "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0"
     },
     "bin": [
         "covers-validator"


### PR DESCRIPTION
I skimmed the code used by covers-validator and didn't see anything that required any changes - and symfony/console has been very stable in the past.