### PR TITLE
Add compatibility switch for PHPUnit >= 9.3

### DIFF
--- a/src/Loader/ConfigLoader.php
+++ b/src/Loader/ConfigLoader.php
@@ -26,15 +26,14 @@ class ConfigLoader
             }
             // @codeCoverageIgnoreEnd
         } else {
-            // PHPUnit < 9.3
             if (class_exists('PHPUnit\TextUI\Configuration\Loader', true)) {
+                // PHPUnit < 9.3
                 $loader = new \PHPUnit\TextUI\Configuration\Loader();
-            }
-            // PHPUnit >= 9.3
-            elseif (class_exists('PHPUnit\TextUI\XmlConfiguration\Loader', true)) {
+            } elseif (class_exists('PHPUnit\TextUI\XmlConfiguration\Loader', true)) {
+                // PHPUnit >= 9.3
                 $loader = new \PHPUnit\TextUI\XmlConfiguration\Loader();
             } else {
-                throw new \RuntimeException('Could not find PHPUnit\'s configuration loader class.');
+                throw new \RuntimeException('Could not find PHPUnit configuration loader class');
             }
 
             $configuration = $loader->load($fileName);

--- a/src/Loader/ConfigLoader.php
+++ b/src/Loader/ConfigLoader.php
@@ -3,7 +3,6 @@
 namespace OckCyp\CoversValidator\Loader;
 
 use OckCyp\CoversValidator\Model\ConfigurationHolder;
-use PHPUnit\TextUI\Configuration\Loader;
 use PHPUnit\Util\Configuration;
 
 class ConfigLoader
@@ -27,7 +26,16 @@ class ConfigLoader
             }
             // @codeCoverageIgnoreEnd
         } else {
-            $loader = new Loader();
+            // PHPUnit < 9.3
+            if (class_exists('PHPUnit\TextUI\Configuration\Loader', true)) {
+                $loader = new \PHPUnit\TextUI\Configuration\Loader();
+            }
+            // PHPUnit >= 9.3
+            elseif (class_exists('PHPUnit\TextUI\XmlConfiguration\Loader', true)) {
+                $loader = new \PHPUnit\TextUI\XmlConfiguration\Loader();
+            } else {
+                throw new \RuntimeException('Could not find PHPUnit\'s configuration loader class.');
+            }
 
             $configuration = $loader->load($fileName);
             $filename = $configuration->filename();

--- a/src/Model/TestCollection.php
+++ b/src/Model/TestCollection.php
@@ -3,7 +3,6 @@
 namespace OckCyp\CoversValidator\Model;
 
 use PHPUnit\Util\Configuration as PHPUnit8Configuration;
-use PHPUnit\TextUI\Configuration\TestSuiteMapper;
 
 class TestCollection implements \Iterator
 {
@@ -24,7 +23,16 @@ class TestCollection implements \Iterator
         if ($configuration instanceof PHPUnit8Configuration) {
             $this->iterator = $configuration->getTestSuiteConfiguration();
         } else {
-            $testSuiteMapper = new TestSuiteMapper();
+            // PHPUnit < 9.3
+            if (class_exists('PHPUnit\TextUI\Configuration\TestSuiteMapper', true)) {
+                $testSuiteMapper = new \PHPUnit\TextUI\Configuration\TestSuiteMapper();
+            }
+            // PHPUnit >= 9.3
+            elseif (class_exists('PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper', true)) {
+                $testSuiteMapper = new \PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper();
+            } else {
+                throw new \RuntimeException('Could not find PHPUnit\'s TestSuiteMapper class.');
+            }
 
             $this->iterator = $testSuiteMapper->map($configuration->testSuite(), '');
         }

--- a/src/Model/TestCollection.php
+++ b/src/Model/TestCollection.php
@@ -23,15 +23,14 @@ class TestCollection implements \Iterator
         if ($configuration instanceof PHPUnit8Configuration) {
             $this->iterator = $configuration->getTestSuiteConfiguration();
         } else {
-            // PHPUnit < 9.3
             if (class_exists('PHPUnit\TextUI\Configuration\TestSuiteMapper', true)) {
+                // PHPUnit < 9.3
                 $testSuiteMapper = new \PHPUnit\TextUI\Configuration\TestSuiteMapper();
-            }
-            // PHPUnit >= 9.3
-            elseif (class_exists('PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper', true)) {
+            } elseif (class_exists('PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper', true)) {
+                // PHPUnit >= 9.3
                 $testSuiteMapper = new \PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper();
             } else {
-                throw new \RuntimeException('Could not find PHPUnit\'s TestSuiteMapper class.');
+                throw new \RuntimeException('Could not find PHPUnit TestSuiteMapper class');
             }
 
             $this->iterator = $testSuiteMapper->map($configuration->testSuite(), '');


### PR DESCRIPTION
covers-validator uses PHPUnit's internal configuration loader classes to
find the tests that PHPUnit will run. The internal classes have been
moved to a different namespace in release 9.3. This patch restores
compatibility with PHPUnit 9.3 by allowing for both namespaces.

This fixes #28 