### PR TITLE
Fix config loader name

### DIFF
--- a/src/Model/TestCollection.php
+++ b/src/Model/TestCollection.php
@@ -28,7 +28,7 @@ class TestCollection implements \Iterator
                 $testSuiteMapper = new \PHPUnit\TextUI\Configuration\TestSuiteMapper();
             } elseif (class_exists('PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper', true)) {
                 // PHPUnit >= 9.3 & < 9.5
-                $testSuiteMapper = new \PHPUnit\TextUI\XmlConfiguration\TestSuiteMappe();
+                $testSuiteMapper = new \PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper();
             } elseif (class_exists('PHPUnit\TextUI\TestSuiteMapper', true)) {
                 // PHPUnit >= 9.5
                 $testSuiteMapper = new \PHPUnit\TextUI\TestSuiteMapper();


### PR DESCRIPTION
The loader name for PHPUnit was accidentally shortened in #33

Fixes #34