### PR TITLE
Update for PHP 8.1 support

### DIFF
--- a/src/Locator/ConfigLocator.php
+++ b/src/Locator/ConfigLocator.php
@@ -14,6 +14,10 @@ class ConfigLocator
      */
     public static function locate($configOption)
     {
+        if (is_null($configOption)) {
+            $configOption = '';
+        }
+
         $configurationFile = static::CONFIG_FILENAME;
         if (is_dir($configOption)) {
             $configurationFile = $configOption . DIRECTORY_SEPARATOR . $configurationFile;

--- a/src/Model/TestCollection.php
+++ b/src/Model/TestCollection.php
@@ -42,22 +42,22 @@ class TestCollection implements \Iterator
         $this->iteratorIterator = new \RecursiveIteratorIterator($this->iterator);
     }
 
-    public function current()
+    public function current(): mixed
     {
         return $this->iteratorIterator->current();
     }
 
-    public function key()
+    public function key(): mixed
     {
         return $this->iteratorIterator->key();
     }
 
-    public function next()
+    public function next(): void
     {
         $this->iteratorIterator->next();
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->iteratorIterator->rewind();
     }

--- a/src/Model/TestCollection.php
+++ b/src/Model/TestCollection.php
@@ -42,7 +42,11 @@ class TestCollection implements \Iterator
         $this->iteratorIterator = new \RecursiveIteratorIterator($this->iterator);
     }
 
-    public function current(): mixed
+    /**
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return $this->iteratorIterator->current();
     }

--- a/src/Model/TestCollection.php
+++ b/src/Model/TestCollection.php
@@ -51,7 +51,11 @@ class TestCollection implements \Iterator
         return $this->iteratorIterator->current();
     }
 
-    public function key(): mixed
+    /**
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function key()
     {
         return $this->iteratorIterator->key();
     }


### PR DESCRIPTION
The return types are pretty clear here, but we weren't sure the preferred behavior for the `null` `$configOption`, whether it would be to enforce strings, or do the following behavior.

(PR'ed to support humbug/php-scoper updating to support 8.1: https://github.com/humbug/php-scoper/issues/530)