### PR TITLE
Allow `symfony/console` 6.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.0 || ^8.0",
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0"
+        "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
     },
     "bin": [
         "covers-validator"

--- a/src/Application/CoversValidator.php
+++ b/src/Application/CoversValidator.php
@@ -2,50 +2,98 @@
 
 namespace OckCyp\CoversValidator\Application;
 
+use Composer\InstalledVersions;
 use OckCyp\CoversValidator\Command\ValidateCommand;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 
-class CoversValidator extends Application
-{
-    const NAME = 'CoversValidator';
-    const VERSION = '1.4.0';
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __construct($name = self::NAME, $version = self::VERSION)
+if (version_compare(InstalledVersions::getVersion('symfony/console'), '6.0.0') >= 0) {
+    class CoversValidator extends Application
     {
-        parent::__construct($name, $version);
+        const NAME = 'CoversValidator';
+        const VERSION = '1.4.0';
+
+        /**
+         * {@inheritdoc}
+         */
+        public function __construct($name = self::NAME, $version = self::VERSION)
+        {
+            parent::__construct($name, $version);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        protected function getCommandName(InputInterface $input): ?string
+        {
+            return 'validate';
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        protected function getDefaultCommands(): array
+        {
+            $defaultCommands = parent::getDefaultCommands();
+            $defaultCommands[] = new ValidateCommand;
+
+            return $defaultCommands;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getDefinition(): InputDefinition
+        {
+            $inputDefinition = parent::getDefinition();
+            $inputDefinition->setArguments();
+
+            return $inputDefinition;
+        }
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCommandName(InputInterface $input)
+} else {
+    class CoversValidator extends Application
     {
-        return 'validate';
-    }
+        const NAME = 'CoversValidator';
+        const VERSION = '1.4.0';
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getDefaultCommands()
-    {
-        $defaultCommands = parent::getDefaultCommands();
-        $defaultCommands[] = new ValidateCommand;
+        /**
+         * {@inheritdoc}
+         */
+        public function __construct($name = self::NAME, $version = self::VERSION)
+        {
+            parent::__construct($name, $version);
+        }
 
-        return $defaultCommands;
-    }
+        /**
+         * {@inheritdoc}
+         */
+        protected function getCommandName(InputInterface $input)
+        {
+            return 'validate';
+        }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefinition()
-    {
-        $inputDefinition = parent::getDefinition();
-        $inputDefinition->setArguments();
+        /**
+         * {@inheritdoc}
+         */
+        protected function getDefaultCommands()
+        {
+            $defaultCommands = parent::getDefaultCommands();
+            $defaultCommands[] = new ValidateCommand;
 
-        return $inputDefinition;
+            return $defaultCommands;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getDefinition()
+        {
+            $inputDefinition = parent::getDefinition();
+            $inputDefinition->setArguments();
+
+            return $inputDefinition;
+        }
     }
 }


### PR DESCRIPTION
A Symfony 6.0+ test is required because of function signatures change in `Console\Application`.
Maybe a better test exists instead of [Runtime Composer utilities](https://getcomposer.org/doc/07-runtime.md#knowing-whether-package-x-is-installed-in-version-y).