### PR TITLE
CI: Fix PHPUnit 8+ failing when prophecy is not installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ php:
   - 8.1.0
 
 env:
-  - COVERAGE=0
-  - INSTALL_PROPHECY=1
+  - COVERAGE=0 INSTALL_PROPHECY=1
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ php:
   - 8.0
   - 8.1.0
 
-env: COVERAGE=0
+env:
+  - COVERAGE=0
+  - INSTALL_PROPHECY=1
 
 matrix:
   include:
@@ -16,9 +18,13 @@ matrix:
       env: COVERAGE=1
     - php: 7.0
       dist: xenial
+      env: INSTALL_PROPHECY=0
+    - php: 7.1
+      env: INSTALL_PROPHECY=0
 
 before_script:
   - if [[ "$COVERAGE" -eq 0 ]]; then composer install; else composer require php-coveralls/php-coveralls --dev; fi
+  - if [[ "$INSTALL_PROPHECY" -eq 1 ]]; then composer require phpspec/prophecy --dev; fi
 
 script:
   - if [[ "$COVERAGE" -eq 0 ]]; then vendor/bin/phpunit; else mkdir -p build/logs; vendor/bin/phpunit --coverage-clover=build/logs/clover.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 matrix:
   include:
     - php: 7.4
-      env: COVERAGE=1
+      env: COVERAGE=1 INSTALL_PROPHECY=1
     - php: 7.0
       dist: xenial
       env: INSTALL_PROPHECY=0

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0",
         "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0"
     },
-    "require-dev": {},
     "bin": [
         "covers-validator"
     ],

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0",
         "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0"
     },
+    "require-dev": {},
     "bin": [
         "covers-validator"
     ],


### PR DESCRIPTION
Instruct Travis CI to install prophecy for PHP 7.2 and above