### PR TITLE
Finish adding PHPUnit 10 support and test with PHP 8.2 and 8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,8 @@ jobs:
           - 7.4
           - 8.0
           - 8.1
+          - 8.2
+          - 8.3
         include:
           - php: 7.1
             no-prophecy: "1"
@@ -70,8 +72,9 @@ jobs:
       - name: Create build/logs
         run: mkdir -p build/logs
       - name: Run tests
-        run: vendor/bin/phpunit --coverage-clover=build/logs/clover.xml
+        run: vendor/bin/phpunit -c phpunit10.xml.dist --coverage-clover=build/logs/clover.xml
       - name: Upload coverage
+        if: ${{ github.repository == 'oradwell/covers-validator' }} # skip on forks, needs secret
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: vendor/bin/php-coveralls

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,9 +6,4 @@
       <exclude>tests/Fixtures/</exclude>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist processUncoveredFilesFromWhitelist="true">
-      <directory suffix=".php">src/</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Covers Validator Test Suite">
+      <directory suffix="Test.php">tests/</directory>
+      <exclude>tests/Fixtures/</exclude>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
+</phpunit>

--- a/src/Command/ValidateCommand.php
+++ b/src/Command/ValidateCommand.php
@@ -73,8 +73,10 @@ class ValidateCommand extends Command
 
             $testClass = get_class($suite);
             if (method_exists($suite, 'getName')) {
+                // PHPUnit < 10
                 $testMethod = $suite->getName(false);
             } elseif (method_exists($suite, 'name')) {
+                // PHPUnit >= 10.0
                 $testMethod = $suite->name();
             } else {
                 $testMethod = $suite->toString();

--- a/src/Loader/ConfigLoader.php
+++ b/src/Loader/ConfigLoader.php
@@ -3,7 +3,10 @@
 namespace OckCyp\CoversValidator\Loader;
 
 use OckCyp\CoversValidator\Model\ConfigurationHolder;
-use PHPUnit\Util\Configuration;
+use PHPUnit\Runner\Version;
+use PHPUnit\TextUI\Configuration\Loader as PHPUnit9ConfigurationLoader;
+use PHPUnit\TextUI\XmlConfiguration\Loader as PHPUnit10ConfigurationLoader;
+use PHPUnit\Util\Configuration as PHPUnit8Configuration;
 
 class ConfigLoader
 {
@@ -12,9 +15,10 @@ class ConfigLoader
      */
     public static function loadConfig(string $fileName): ConfigurationHolder
     {
-        if (class_exists(Configuration::class)) {
+        if ((int) Version::series() <= 8 && class_exists(PHPUnit8Configuration::class)) {
             // @codeCoverageIgnoreStart
-            $configuration = Configuration::getInstance($fileName);
+            // PHPUnit 8.x
+            $configuration = PHPUnit8Configuration::getInstance($fileName);
             $filename = $configuration->getFilename();
             $phpunit = $configuration->getPHPUnitConfiguration();
             $bootstrap = '';
@@ -22,13 +26,13 @@ class ConfigLoader
                 $bootstrap = $phpunit['bootstrap'];
             }
         } else {
-            if (class_exists('PHPUnit\TextUI\Configuration\Loader', true)) {
+            if (class_exists(PHPUnit9ConfigurationLoader::class)) {
                 // PHPUnit < 9.3
-                $loader = new \PHPUnit\TextUI\Configuration\Loader();
+                $loader = new PHPUnit9ConfigurationLoader();
             // @codeCoverageIgnoreEnd
-            } elseif (class_exists('PHPUnit\TextUI\XmlConfiguration\Loader', true)) {
+            } elseif (class_exists(PHPUnit10ConfigurationLoader::class)) {
                 // PHPUnit >= 9.3
-                $loader = new \PHPUnit\TextUI\XmlConfiguration\Loader();
+                $loader = new PHPUnit10ConfigurationLoader();
             } else {
                 throw new \RuntimeException('Could not find PHPUnit configuration loader class'); // @codeCoverageIgnore
             }

--- a/src/Loader/FileLoader.php
+++ b/src/Loader/FileLoader.php
@@ -13,6 +13,7 @@ class FileLoader
     {
         if (class_exists(\PHPUnit\Util\FileLoader::class, true)) {
             \PHPUnit\Util\FileLoader::checkAndLoad($filename);
+
             return;
         }
 

--- a/src/Model/ConfigurationHolder.php
+++ b/src/Model/ConfigurationHolder.php
@@ -2,13 +2,14 @@
 
 namespace OckCyp\CoversValidator\Model;
 
-use PHPUnit\TextUI\Configuration\Configuration;
+use PHPUnit\TextUI\Configuration\Configuration as PHPUnit9Configuration;
+use PHPUnit\TextUI\XmlConfiguration\Configuration as PHPUnit10Configuration;
 use PHPUnit\Util\Configuration as PHPUnit8Configuration;
 
 class ConfigurationHolder
 {
     /**
-     * @var PHPUnit8Configuration|Configuration
+     * @var PHPUnit8Configuration|PHPUnit9Configuration|PHPUnit10Configuration
      */
     private $configuration;
 
@@ -23,7 +24,7 @@ class ConfigurationHolder
     private $bootstrap;
 
     /**
-     * @param PHPUnit8Configuration|Configuration $configuration
+     * @param PHPUnit8Configuration|PHPUnit9Configuration|PHPUnit10Configuration $configuration
      * @param string|null $bootstrap
      */
     public function __construct($configuration, string $filename, $bootstrap)

--- a/src/Model/TestCollection.php
+++ b/src/Model/TestCollection.php
@@ -2,6 +2,7 @@
 
 namespace OckCyp\CoversValidator\Model;
 
+use PHPUnit\Runner\Version;
 use PHPUnit\Util\Configuration as PHPUnit8Configuration;
 
 class TestCollection implements \Iterator
@@ -20,22 +21,41 @@ class TestCollection implements \Iterator
     {
         $configuration = $configurationHolder->getConfiguration();
 
-        if ($configuration instanceof PHPUnit8Configuration) {
-            // @codeCoverageIgnoreStart
-            $this->iterator = $configuration->getTestSuiteConfiguration();
-        } else {
-            if (class_exists('PHPUnit\TextUI\Configuration\TestSuiteMapper', true)) {
+        // @codeCoverageIgnoreStart
+        if ((int) Version::series() < 10) {
+            if ($configuration instanceof PHPUnit8Configuration) {
+                $this->iterator = $configuration->getTestSuiteConfiguration();
+            } elseif (class_exists('PHPUnit\TextUI\Configuration\TestSuiteMapper')) {
                 // PHPUnit < 9.3
                 $testSuiteMapper = new \PHPUnit\TextUI\Configuration\TestSuiteMapper();
-            } elseif (class_exists('PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper', true)) {
-                // PHPUnit >= 9.3
+                $this->iterator = $testSuiteMapper->map($configuration->testSuite(), '');
+            } elseif (class_exists('PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper')) {
+                // PHPUnit 9.3, 9.4
                 $testSuiteMapper = new \PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper();
-            // @codeCoverageIgnoreEnd
-            } else {
-                throw new \RuntimeException('Could not find PHPUnit TestSuiteMapper class'); // @codeCoverageIgnore
+                $this->iterator = $testSuiteMapper->map($configuration->testSuite(), '');
+            } elseif (class_exists('PHPUnit\TextUI\TestSuiteMapper')) {
+                // PHPUnit 9.5, 9.6
+                $testSuiteMapper = new \PHPUnit\TextUI\TestSuiteMapper();
+                $this->iterator = $testSuiteMapper->map($configuration->testSuite(), '');
             }
+        // @codeCoverageIgnoreEnd
+        } else {
+            // PHPUnit >= 10.0: same name as PHPUnit 9.3, but map() takes different args.
+            if (class_exists('PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper')) {
+                $testSuiteMapper = new \PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper();
 
-            $this->iterator = $testSuiteMapper->map($configurationHolder->getFilename(), $configuration->testSuite(), '', '');
+                // TestSuiteMapper eventually calls TestBuilder->configureTestCase,
+                // which requires the ConfigurationRegistry singleton to be populated.
+                \PHPUnit\TextUI\Configuration\Registry::init(
+                    (new \PHPUnit\TextUI\CliArguments\Builder())->fromParameters([]),
+                    $configuration
+                );
+                $this->iterator = $testSuiteMapper->map($configurationHolder->getFilename(), $configuration->testSuite(), '', '');
+            }
+        }
+
+        if (!$this->iterator) {
+            throw new \RuntimeException('Could not find PHPUnit TestSuiteMapper class'); // @codeCoverageIgnore
         }
 
         $this->iteratorIterator = new \RecursiveIteratorIterator($this->iterator);

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -3,10 +3,39 @@
 namespace OckCyp\CoversValidator\Tests;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Version;
+use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
+use ReflectionClass;
 
 abstract class BaseTestCase extends TestCase
 {
     public const FIXTURE_NS_PREFIX = 'OckCyp\CoversValidator\Tests\Fixtures\\';
+
+    private $configRegistryInstance = null;
+
+    /**
+     * @before
+     */
+    protected function savePHPUnitState()
+    {
+        // Manipulated by TestSuiteLoader::loadSuite/TestCollection for PHPUnit 10+
+        if (class_exists(ConfigurationRegistry::class) && (int) Version::series() >= 10) {
+            $class = new ReflectionClass(ConfigurationRegistry::class);
+            $this->configRegistryInstance = $class->getProperty('instance')->getValue();
+        }
+    }
+
+    /**
+     * @after
+     */
+    protected function restorePHPUnitState()
+    {
+        if ($this->configRegistryInstance) {
+            $class = new ReflectionClass(ConfigurationRegistry::class);
+            $class->getProperty('instance')->setValue(null, $this->configRegistryInstance);
+            $this->configRegistryInstance = null;
+        }
+    }
 
     /**
      * Returns the namespace of fixture class

--- a/tests/FileTestCase.php
+++ b/tests/FileTestCase.php
@@ -4,19 +4,48 @@ namespace OckCyp\CoversValidator\Tests;
 
 abstract class FileTestCase extends BaseTestCase
 {
-    /**
-     * {@inheritdoc}
-     */
+    /** @var string */
+    private $runDir;
+    /** @var string */
+    private $tmpDir;
+
     protected function setUp(): void
     {
-        $this->preTestRun();
+        $this->runDir = getcwd();
+        $this->tmpDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'covers-validator';
+        mkdir($this->tmpDir);
+        chdir($this->tmpDir);
+    }
+
+    protected function tearDown(): void
+    {
+        chdir($this->runDir);
+
+        // Delete the temp directory
+        self::recursiveRmDir($this->tmpDir);
     }
 
     /**
-     * {@inheritdoc}
+     * Recursively deletes a directory
+     *
+     * @param string $directory
      */
-    protected function tearDown(): void
+    private static function recursiveRmDir($directory)
     {
-        $this->postTestRun();
+        foreach (scandir($directory) as $filename) {
+            if ('.' === $filename || '..' === $filename) {
+                continue;
+            }
+
+            $path = $directory.DIRECTORY_SEPARATOR.$filename;
+            if (is_dir($path)) {
+                self::recursiveRmDir($path);
+                continue;
+            }
+
+            unlink($path);
+        }
+
+        rmdir($directory);
     }
 }

--- a/tests/Fixtures/MultiClassTwoTest.php
+++ b/tests/Fixtures/MultiClassTwoTest.php
@@ -6,4 +6,8 @@ use PHPUnit\Framework\TestCase;
 
 class MultiClassTwoTest extends TestCase
 {
+    public function testDoesSomething()
+    {
+        $this->assertTrue(true);
+    }
 }

--- a/tests/Fixtures/OneTestCoveringNonExistentClassTest.php
+++ b/tests/Fixtures/OneTestCoveringNonExistentClassTest.php
@@ -3,7 +3,6 @@
 namespace OckCyp\CoversValidator\Tests\Fixtures;
 
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\Attributes\CoversClass;
 
 class OneTestCoveringNonExistentClassTest extends TestCase
 {

--- a/tests/Fixtures/OneTestWithProviderCoveringExistingClassTest.php
+++ b/tests/Fixtures/OneTestWithProviderCoveringExistingClassTest.php
@@ -16,7 +16,7 @@ class OneTestWithProviderCoveringExistingClassTest extends TestCase
         $this->assertTrue(true);
     }
 
-    public function provideDummyTest()
+    public static function provideDummyTest()
     {
         return [
             ['x'],

--- a/tests/Fixtures/OneTestWithProviderCoveringNonExistentClassTest.php
+++ b/tests/Fixtures/OneTestWithProviderCoveringNonExistentClassTest.php
@@ -16,7 +16,7 @@ class OneTestWithProviderCoveringNonExistentClassTest extends TestCase
         $this->assertTrue(true);
     }
 
-    public function provideDummyTest()
+    public static function provideDummyTest()
     {
         return [
             ['x'],

--- a/tests/Handler/InputHandlerTest.php
+++ b/tests/Handler/InputHandlerTest.php
@@ -5,6 +5,7 @@ namespace OckCyp\CoversValidator\Tests\Handler;
 use OckCyp\CoversValidator\Handler\InputHandler;
 use OckCyp\CoversValidator\Model\ConfigurationHolder;
 use OckCyp\CoversValidator\Tests\BaseTestCase;
+use Prophecy\Prophet;
 
 /**
  * @coversDefaultClass \OckCyp\CoversValidator\Handler\InputHandler
@@ -12,11 +13,32 @@ use OckCyp\CoversValidator\Tests\BaseTestCase;
 class InputHandlerTest extends BaseTestCase
 {
     /**
+     * @var Prophet|null
+     */
+    private $prophet;
+
+    /**
+     * @before
+     */
+    protected function setUpProphet()
+    {
+        $this->prophet = new Prophet();
+    }
+
+    /**
+     * @after
+     */
+    protected function tearDownProphet()
+    {
+        $this->prophet->checkPredictions();
+    }
+
+    /**
      * @covers ::handleInput
      */
     public function testHandlesInputWithNoBootstrap()
     {
-        $input = $this->prophesize(
+        $input = $this->prophet->prophesize(
             'Symfony\Component\Console\Input\InputInterface'
         );
         $input->getOption('configuration')
@@ -36,7 +58,7 @@ class InputHandlerTest extends BaseTestCase
      */
     public function testHandlesInputWithBootstrapInConfig()
     {
-        $input = $this->prophesize(
+        $input = $this->prophet->prophesize(
             'Symfony\Component\Console\Input\InputInterface'
         );
         $input->getOption('configuration')
@@ -68,7 +90,7 @@ class InputHandlerTest extends BaseTestCase
      */
     public function testBootstrapInInputOverridesConfig()
     {
-        $input = $this->prophesize(
+        $input = $this->prophet->prophesize(
             'Symfony\Component\Console\Input\InputInterface'
         );
         $input->getOption('configuration')

--- a/tests/Loader/FileLoaderTest.php
+++ b/tests/Loader/FileLoaderTest.php
@@ -4,26 +4,50 @@ namespace OckCyp\CoversValidator\Tests\Loader;
 
 use OckCyp\CoversValidator\Loader\FileLoader;
 use OckCyp\CoversValidator\Tests\FileTestCase;
+use PHPUnit\Runner\Version;
 
 class FileLoaderTest extends FileTestCase
 {
     /**
      * @covers \OckCyp\CoversValidator\Loader\FileLoader::loadFile
      */
-    public function testLoadsFile()
+    public function testLoadsFileWithVar()
     {
-        file_put_contents('my1.php', '<?php $cv_global_var = true;');
-        FileLoader::loadFile('my1.php');
+        // NOTE: Version::majorVersionNumber exists in PHPUnit 10+ only
+        if ((int) Version::series() >= 10) {
+            $this->markTestSkipped('Only for PHPUnit 9 and below');
+
+            return;
+        }
+
+        file_put_contents('myvar1.php', '<?php $cv_global_var = true;');
+        FileLoader::loadFile('myvar1.php');
         $this->assertTrue(isset($GLOBALS['cv_global_var']));
     }
 
     /**
      * @covers \OckCyp\CoversValidator\Loader\FileLoader::loadFile
      */
-    public function testLoadsFile2()
+    public function testLoadsFileWithVar2()
     {
-        file_put_contents('my2.php', '<?php $cv_global_var = true;');
-        FileLoader::loadFile('my2.php');
+        if ((int) Version::series() >= 10) {
+            $this->markTestSkipped('Only for PHPUnit 9 and below');
+
+            return;
+        }
+
+        file_put_contents('myvar2.php', '<?php $cv_global_var = true;');
+        FileLoader::loadFile('myvar2.php');
         $this->assertTrue(isset($GLOBALS['cv_global_var']));
+    }
+
+    /**
+     * @covers \OckCyp\CoversValidator\Loader\FileLoader::loadFile
+     */
+    public function testLoadsFileWithFunc()
+    {
+        file_put_contents('myfunc.php', '<?php function ockcyp_covers_valid_example() {}');
+        FileLoader::loadFile('myfunc.php');
+        $this->assertTrue(function_exists('ockcyp_covers_valid_example'));
     }
 }

--- a/tests/Loader/TestSuiteLoaderTest.php
+++ b/tests/Loader/TestSuiteLoaderTest.php
@@ -2,62 +2,32 @@
 
 namespace OckCyp\CoversValidator\Tests\Loader;
 
+use OckCyp\CoversValidator\Loader\ConfigLoader;
 use OckCyp\CoversValidator\Loader\TestSuiteLoader;
-use OckCyp\CoversValidator\Model\ConfigurationHolder;
 use OckCyp\CoversValidator\Model\TestCollection;
 use OckCyp\CoversValidator\Tests\BaseTestCase;
-use PHPUnit\TextUI\Configuration\Configuration as PHPUnit9Configuration;
-use PHPUnit\TextUI\Configuration\Loader as PHPUnit9ConfigurationLoader;
-use PHPUnit\Util\Configuration as PHPUnit8Configuration;
+use PHPUnit\Runner\Version;
 
 class TestSuiteLoaderTest extends BaseTestCase
 {
     /**
      * @covers \OckCyp\CoversValidator\Loader\TestSuiteLoader::loadSuite
-     */
-    public function testLoadsSuitePHPUnit8()
-    {
-        if (!class_exists(PHPUnit8Configuration::class)) {
-            $this->markTestSkipped('Only for PHPUnit 8 and below');
-        }
-
-        $configuration = PHPUnit8Configuration::getInstance('tests/Fixtures/configuration-existing-2.xml');
-
-        $configurationHolder = new ConfigurationHolder($configuration, '', '');
-
-        $testCollection = TestSuiteLoader::loadSuite($configurationHolder);
-
-        $this->assertInstanceOf(TestCollection::class, $testCollection);
-
-        foreach ($testCollection as $test) {
-            $this->assertEquals('testDummyTest', $test->getName());
-
-            return;
-        }
-    }
-
-    /**
-     * @covers \OckCyp\CoversValidator\Loader\TestSuiteLoader::loadSuite
      * @covers \OckCyp\CoversValidator\Model\TestCollection
      */
-    public function testLoadsSuitePHPUnit9()
+    public function testLoadSuite()
     {
-        if (!class_exists(PHPUnit9Configuration::class)) {
-            $this->markTestSkipped('Only for PHPUnit 9 and above');
-        }
-
-        $loader = new PHPUnit9ConfigurationLoader();
-
-        $configuration = $loader->load('tests/Fixtures/configuration-existing-2.xml');
-
-        $configurationHolder = new ConfigurationHolder($configuration, '', '');
-
+        $configurationHolder = ConfigLoader::loadConfig('tests/Fixtures/configuration-existing-2.xml');
         $testCollection = TestSuiteLoader::loadSuite($configurationHolder);
 
         $this->assertInstanceOf(TestCollection::class, $testCollection);
 
         foreach ($testCollection as $key => $test) {
-            $this->assertEquals('testDummyTest', $test->getName());
+            if ((int) Version::series() < 10) {
+                $name = $test->getName();
+            } else {
+                $name = $test->name();
+            }
+            $this->assertEquals('testDummyTest', $name);
 
             return;
         }


### PR DESCRIPTION
Finish adding PHPUnit 10 support

### Issues with PHPUnit 9.6 on PHP 7.4

```
1) OckCyp\CoversValidator\Tests\Command\ValidateCommandTest::testPrintsConfigFileUsed
RuntimeException: Could not find PHPUnit TestSuiteMapper class
```

Restore the PHPUnit 9.3 and 9.5 logic from the master branch.

In PHPUnit 10, TestSuiteMapper was renamed to the same name as 9.3,
but takes different args. This means the map() call needs to become
part of the conditional. It also requires the ConfigurationRegistry
singleton to be populated, because otherwise:

> $ vendor/bin/covers-validator
> CoversValidator 1.6.0
> PHP Fatal error:  Uncaught AssertionError: assert(self::$instance instanceof Configuration)
>   in /vendor/phpunit/phpunit/src/TextUI/Configuration/Registry.php:93
> Stack trace:
> /vendor/phpunit/phpunit/src/TextUI/Configuration/Registry.php(93)
> /vendor/phpunit/phpunit/src/Framework/TestBuilder.php(128): Registry::get
> /vendor/phpunit/phpunit/src/Framework/TestBuilder.php(63): TestBuilder->configureTestCase
> /vendor/phpunit/phpunit/src/Framework/TestSuite.php(511): …
> /vendor/phpunit/phpunit/src/TextUI/Configuration/Xml/TestSuiteMapper.php(102): …
> /vendor/ockcyp/covers-validator/src/Model/TestCollection.php(50): TestSuiteMapper->map

### Issues with PHPUnit 10 on PHP 8

```
…\InputHandlerTest::testHandlesInputWithNoBootstrap
Error: Call to undefined method …\InputHandlerTest::prophesize()
```

https://github.com/sebastianbergmann/phpunit/blob/9.6.26/DEPRECATIONS.md#test-double-api-1
https://phpunit.de/announcements/phpunit-10.html
https://github.com/sebastianbergmann/phpunit/blob/10.0.0/ChangeLog-10.0.md
https://github.com/sebastianbergmann/phpunit/issues/4142

```
…\ConfigLoaderTest::testLoadsConfig
Error: Call to undefined method …\ConfigLoaderTest::preTestRun()
```

Restore previous logic for now, which seemed to work fine.

```
…\TestSuiteLoaderTest::testLoadsSuitePHPUnit9
Error: Class "PHPUnit\TextUI\Configuration\Loader" not found
```

Condition checked an unused PHPUnit9 classes, which happens to exist
on PHPUnit10 as well. The class that is actually used (Loader) was
renamed again.

Update the condition, and write a new test for PHPUnit 10. Note that
TestCase::getName() was removed as well, so update that to use
TestName::name() instead, same as in ValidateCommand already.

In addition, switch the condition from a class check to a version
check because otherwise:

> PHPUnit 9.6.26
> TestSuiteLoaderTest::testLoadsSuitePHPUnit10
> Error: Call to undefined method OneTestCoveringExistingTwoClassTest::name()

... because the PHPUnit 10+ class was first introduced in PHPUnit 9.3.

I realized the same logic exists in ConfigLoader::loadConfig, which
seems worth re-using (and testing) instead, so I've simplified the
test to use that instead.

```
1) OckCyp\CoversValidator\Tests\Loader\FileLoaderTest::testLoadsFile
Failed asserting that false is true.

2) OckCyp\CoversValidator\Tests\Loader\FileLoaderTest::testLoadsFile2
Failed asserting that false is true.
```

In PHPUnit 10, the FileLoader::checkAndLoad utility was removed,
and with it support for setting global variables from there.
The equivalent is simply include_once and that is what PHPUnit 10+
does as well.

The example test here, however, expected PHPUnit 9-specific behavior.
Skip it under PHPUnit 10+ and write a new test that defines a function
instead, which does not rely on emulating global scope for vars.

```
1) …\OneTestWithProviderCoveringNonExistentClassTest::testDummyTest
Data Provider method provideDummyTest() is not static

2) …\OneTestWithProviderCoveringExistingClassTest::testDummyTest
Data Provider method provideDummyTest() is not static
```

Fixed.

### Issues with PHPUnit 10 coverage build

```
Error: No filter is configured, code coverage will not be processed
```

Migrate phpunit.xml.dist, and set the new one for the coverage
build only since it requires PHPUnit 10. It only runs on one
version anyway.

```
Run vendor/bin/php-coveralls
COVERALLS_REPO_TOKEN=""
Error: Process completed with exit code 1.
```

Skip upload step on forks where secret tokens don't apply.
Keep the rest of the coverage build enabled, so that it can
be tested.

Ref https://github.com/oradwell/covers-validator/issues/44.